### PR TITLE
修复 issues#32 中提到的问题

### DIFF
--- a/ports/rtthread/HAL_TCP_rtthread.c
+++ b/ports/rtthread/HAL_TCP_rtthread.c
@@ -172,10 +172,20 @@ int32_t HAL_TCP_Read(_IN_ uintptr_t fd, _OU_ unsigned char *buf, _IN_ size_t len
         ret = recv(tcp_fd, buf + len_recv, len - len_recv, MSG_DONTWAIT);
         if (ret > 0) {
             len_recv += ret;
-        }else if (errno == EINTR || errno == EAGAIN){
+        }
+        else if (0 == ret) 
+        {
+            break;
+        }
+        else 
+        {
+            if (errno == EINTR || errno == EAGAIN)
+            {
+                continue;
+            }
             printf("read fail,try again\n");
             err_code = ERR_TCP_READ_FAILED;
-            continue;
+            break;
         }
     } while (len_recv < len);
 


### PR DESCRIPTION
修复 [issues#32](https://github.com/ucloud/ucloud-iot-rtthread-package/issues/32) 中提到的问题，当检测到 errno == EINTR || errno == EAGAIN 时continue，而不是直接报错重连，测试正常：
```shell
msh />mqtt_test_example start
establish tcp connection with server(host='mqtt-cn-sh2.iot.ucloud.cn', port=[1883])
msh />success to establish tcp, fd=4
mqtt connect success

Cloud Device Construct SuccessDEBUG:   uiot_mqtt_subscribe L#133 topicName=/4080bmtrgjz*****/ZR202005200001/set|packet_id=2|Userdata=(NULL)

subscribe success, packet-id=2
publish qos1 seq=3|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "1","humi": "0"}
publish success, packet-id=3
publish qos1 seq=4|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "3","humi": "2"}
publish success, packet-id=4
publish qos1 seq=5|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "5","humi": "4"}
publish success, packet-id=5
publish qos1 seq=6|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "7","humi": "6"}
publish success, packet-id=6
publish qos1 seq=7|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "9","humi": "8"}
publish success, packet-id=7
publish qos1 seq=8|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "11","humi": "10"}
publish success, packet-id=8
publish qos1 seq=9|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "13","humi": "12"}
publish success, packet-id=9
publish qos1 seq=10|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "15","humi": "14"}
publish success, packet-id=10
publish qos1 seq=11|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "17","humi": "16"}
publish success, packet-id=11
publish qos1 seq=12|topicName=/4080bmtrgjz*****/ZR202005200001/upload|payload={"temp": "19","humi": "18"}
publish success, packet-id=12
mqtt disconnect!
```